### PR TITLE
Some of the buttons can now be held down 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ barco-slm-net*
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
 
+/.vs

--- a/go/static/index.html
+++ b/go/static/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+﻿<!DOCTYPE html>
 <html lang="en">
 
 <head>
@@ -31,10 +31,10 @@
             <button class="btn" onclick="apirequest('freezeoff','')">Aus</button>
 
             <h2>Arrows</h2>
-            <button class="btn" onclick="apirequest('infrared','arrowup')">Up</button>
-            <button class="btn" onclick="apirequest('infrared','arrowdown')">Down</button>
-            <button class="btn" onclick="apirequest('infrared','arrowleft')">Left</button>
-            <button class="btn" onclick="apirequest('infrared','arrowright')">Right</button>
+            <button class="btn" onmousedown="apiButtonHold('infrared','arrowup')" onmouseout="apiButtonRelease()" onmouseup="apiButtonRelease()">Up</button>
+            <button class="btn" onmousedown="apiButtonHold('infrared','arrowdown')" onmouseout="apiButtonRelease()" onmouseup="apiButtonRelease()">Down</button>
+            <button class="btn" onmousedown="apiButtonHold('infrared','arrowleft')" onmouseout="apiButtonRelease()" onmouseup="apiButtonRelease()">Left</button>
+            <button class="btn" onmousedown="apiButtonHold('infrared','arrowright')" onmouseout="apiButtonRelease()" onmouseup="apiButtonRelease()">Right</button>
 
             <h2>Menü-Buttons</h2>
             <button class="btn" onclick="apirequest('infrared','enter')">Enter</button>
@@ -48,16 +48,16 @@
         <div class="grid-2">
             <h2>Lens</h2>
             <h3>Focus</h3>
-            <button class="btn" onclick="apirequest('lensfocus','near')">Near</button>
-            <button class="btn" onclick="apirequest('lensfocus','far')">Far</button>
+            <button class="btn" onmousedown="apiButtonHold('lensfocus','near')" onmouseout="apiButtonRelease()" onmouseup="apiButtonRelease()">Near</button>
+            <button class="btn" onmousedown="apiButtonHold('lensfocus','far')" onmouseout="apiButtonRelease()" onmouseup="apiButtonRelease()">Far</button>
             <h3>Zoom</h3>
-            <button class="btn" onclick="apirequest('lenszoom','in')">In</button>
-            <button class="btn" onclick="apirequest('lenszoom','out')">Out</button>
+            <button class="btn" onmousedown="apiButtonHold('lenszoom','in')" onmouseout="apiButtonRelease()" onmouseup="apiButtonRelease()">In</button>
+            <button class="btn" onmousedown="apiButtonHold('lenszoom','out')" onmouseout="apiButtonRelease()" onmouseup="apiButtonRelease()">Out</button>
             <h3>Shift</h3>
-            <button class="btn" onclick="apirequest('lensshift','up')">Up</button>
-            <button class="btn" onclick="apirequest('lensshift','down')">Down</button>
-            <button class="btn" onclick="apirequest('lensshift','left')">Left</button>
-            <button class="btn" onclick="apirequest('lensshift','right')">Right</button>
+            <button class="btn" onmousedown="apiButtonHold('lensshift','up')" onmouseout="apiButtonRelease()" onmouseup="apiButtonRelease()">Up</button>
+            <button class="btn" onmousedown="apiButtonHold('lensshift','down')" onmouseout="apiButtonRelease()" onmouseup="apiButtonRelease()">Down</button>
+            <button class="btn" onmousedown="apiButtonHold('lensshift','left')" onmouseout="apiButtonRelease()" onmouseup="apiButtonRelease()">Left</button>
+            <button class="btn" onmousedown="apiButtonHold('lensshift','upright')" onmouseout="apiButtonRelease()" onmouseup="apiButtonRelease()">Right</button>
 
             <h2>Source</h2>
             <button class="btn" onclick="apirequest('source','1')">1</button>

--- a/go/static/index.js
+++ b/go/static/index.js
@@ -73,6 +73,24 @@ function keybindings(e) {
     }
 }
 
+var tid; //timeout ID
+
+function apiButtonHold(cmd, opt) {
+    //Loop apirequests as long as a button is pressed
+
+    var persec = 3; //How many times per second should the API be called?
+
+    apirequest(cmd, opt);
+
+
+    tid = setTimeout(apiButtonHold.bind(null, cmd, opt), Math.round(1000 / persec)); //Repeats the function with the same parameter n times per second, changable via persec variable
+}
+function apiButtonRelease() {
+    //Stop apirequest loop when button is no longer pressed
+    clearTimeout(tid);
+}
+
+
 function particlejsinit() {
     console.log("Loaded particles-js")
     /* ---- particles.js config ---- */


### PR DESCRIPTION
The on screen buttons for arrows, lens shift, focus and zoom now call a js function that loops the API calls n times a second (adjustable with the persec var, default is 3).